### PR TITLE
Chap 9.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ extra["springCloudVersion"] = "2025.0.0"
 
 dependencies {
 	implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webflux")
+    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("io.projectreactor:reactor-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/java/com/polarbookshop/edge_service/config/WebEndpoints.java
+++ b/src/main/java/com/polarbookshop/edge_service/config/WebEndpoints.java
@@ -1,0 +1,32 @@
+package com.polarbookshop.edge_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class WebEndpoints {
+    @Bean
+    public RouterFunction<ServerResponse> routerFunction() {
+        return RouterFunctions.route()
+                                .GET("/catalog-fallback", this::fallbackResponse)
+                .POST("/catalog-fallback", this::fallbackResponse)
+                .build();
+    }
+
+    private Mono<ServerResponse> fallbackResponse(ServerRequest serverRequest) {
+        String errorMessage = """
+                {
+                  "message": "Catalog service is currently unavailable. Please try again later."
+                }
+                """;
+                return ServerResponse.status(HttpStatus.OK)
+                .body(Mono.just(errorMessage), String.class);
+    }
+}
+

--- a/src/main/java/com/polarbookshop/edge_service/config/WebEndpoints.java
+++ b/src/main/java/com/polarbookshop/edge_service/config/WebEndpoints.java
@@ -26,6 +26,7 @@ public class WebEndpoints {
                 }
                 """;
                 return ServerResponse.status(HttpStatus.OK)
+                .header("Content-Type", "application/json")
                 .body(Mono.just(errorMessage), String.class);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,13 +34,13 @@ spring:
                       - name: CircuitBreaker
                         args:
                             name: orderCircuitBreaker
-        httpclient:
-          connect-timeout: 2000
-          response-timeout: 5s
-          pool:
-            type: elastic
-            max-idle-time: 15s
-            max-life-time: 60s
+            httpclient:
+              connect-timeout: 2000
+              response-timeout: 5s
+              pool:
+                type: elastic
+                max-idle-time: 15s
+                max-life-time: 60s
         default-filters:
 # https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway-server-webflux/gatewayfilter-factories/retry-factory.html
           - name: Retry
@@ -67,4 +67,6 @@ resilience4j.timelimiter:
   configs:
     default:
       timeoutDuration: 5s
-
+logging:
+  level:
+    io.github.resilience4j: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,10 +20,20 @@ spring:
                   uri: ${CATALOG_SERVICE_URL:http://localhost:9001}/books
                   predicates:
                       - Path=/books/**
+                  filters:
+# https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway-server-webflux/gatewayfilter-factories/circuitbreaker-filter-factory.html
+                    - name: CircuitBreaker
+                      args:
+                        name: catalogCircuitBreaker
+                        fallbackUri: forward:/catalog-fallback
                 - id: order-route
                   uri: ${ORDER_SERVICE_URL:http://localhost:9002}/orders
                   predicates:
                       - Path=/orders/**
+                  filters:
+                      - name: CircuitBreaker
+                        args:
+                            name: orderCircuitBreaker
         httpclient:
           connect-timeout: 2000
           response-timeout: 5s
@@ -44,3 +54,17 @@ spring:
                   maxBackoff: 500ms
                   factor: 2
                   basedOnPreviousValue: false
+# https://docs.spring.io/spring-cloud-circuitbreaker/reference/spring-cloud-circuitbreaker-resilience4j/circuit-breaker-properties-configuration.html
+#https://resilience4j.readme.io/docs/getting-started-3#configuration
+resilience4j.circuitbreaker:
+  configs:
+    default:
+      slidingWindowSize: 20
+      permittedNumberOfCallsInHalfOpenState: 5
+      failureRateThreshold: 50
+      waitDurationInOpenState: 15000
+resilience4j.timelimiter:
+  configs:
+    default:
+      timeoutDuration: 5s
+


### PR DESCRIPTION
This pull request introduces circuit breaker functionality to the edge service, improving its resilience against downstream service failures. The main changes include configuring circuit breakers for the catalog and order routes, adding fallback handling, and providing custom circuit breaker properties.

**Circuit breaker and fallback integration:**

* Added circuit breaker filters to the catalog and order routes in `application.yml`, with a fallback URI for the catalog route to forward to `/catalog-fallback`.
* Created a new `WebEndpoints` configuration class to handle `/catalog-fallback` requests, returning a friendly error message when the catalog service is unavailable.

**Configuration and observability improvements:**

* Defined custom `resilience4j.circuitbreaker` and `resilience4j.timelimiter` properties in `application.yml` to control circuit breaker behavior (e.g., sliding window size, failure rate threshold, timeout duration).
* Set the logging level for `io.github.resilience4j` to `DEBUG` to aid in monitoring circuit breaker events.