### PR TITLE
9 3 rate limit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ extra["springCloudVersion"] = "2025.0.0"
 dependencies {
 	implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("io.projectreactor:reactor-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/java/com/polarbookshop/edge_service/config/RateLimitConfig.java
+++ b/src/main/java/com/polarbookshop/edge_service/config/RateLimitConfig.java
@@ -1,0 +1,15 @@
+package com.polarbookshop.edge_service.config;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class RateLimitConfig {
+    @Bean
+    public KeyResolver keyResolver() {
+                // Temporary solution until Spring Security is introduced
+        return _ -> Mono.just("anonymous");
+    }
+}

--- a/src/main/java/com/polarbookshop/edge_service/config/WebEndpoints.java
+++ b/src/main/java/com/polarbookshop/edge_service/config/WebEndpoints.java
@@ -25,7 +25,7 @@ public class WebEndpoints {
                   "message": "Catalog service is currently unavailable. Please try again later."
                 }
                 """;
-                return ServerResponse.status(HttpStatus.OK)
+                return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .header("Content-Type", "application/json")
                 .body(Mono.just(errorMessage), String.class);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,18 @@ spring:
                   maxBackoff: 500ms
                   factor: 2
                   basedOnPreviousValue: false
+# https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway-server-webflux/gatewayfilter-factories/requestratelimiter-factory.html#redis-ratelimiter
+          - name: RequestRateLimiter
+            args:
+              redis-rate-limiter.replenishRate: 10
+              redis-rate-limiter.burstCapacity: 20
+              redis-rate-limiter.requestedTokens: 1
+    data:
+      redis:
+        connect-timeout: 2s
+        host: ${REDIS_HOST:localhost}
+        port: ${REDIS_PORT:6379}
+        timeout: 1s
 # https://docs.spring.io/spring-cloud-circuitbreaker/reference/spring-cloud-circuitbreaker-resilience4j/circuit-breaker-properties-configuration.html
 #https://resilience4j.readme.io/docs/getting-started-3#configuration
 resilience4j.circuitbreaker:


### PR DESCRIPTION
This pull request introduces rate limiting to the edge service, configures Redis as the backing store for rate limiting, and improves error handling for service unavailability responses. The changes are primarily focused on enhancing API reliability and protecting backend services from excessive load.

**Rate Limiting Implementation:**

* Added a new `RateLimitConfig` class to define a `KeyResolver` bean, which currently assigns all requests to the "anonymous" user for rate limiting purposes. This is a temporary solution until Spring Security is integrated.
* Updated `application.yml` to configure the `RequestRateLimiter` filter for the gateway, specifying Redis rate limiter properties such as `replenishRate`, `burstCapacity`, and connection details for Redis.

**Error Handling Improvement:**

* Modified the fallback response in `WebEndpoints.java` to return HTTP status `503 Service Unavailable` instead of `200 OK` when the catalog service is unavailable, providing a more accurate indication of service health to clients.