### PR TITLE
9 4 distributed session

### DIFF
--- a/.github/workflows/commit-stage.yaml
+++ b/.github/workflows/commit-stage.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: "Upload vulnerability report"
         uses: "github/codeql-action/upload-sarif@v3"
         with:
-          sarif_file: "${{ steps.scan.outputs.sarif}}"
+          sarif_file: "${{ steps.scan.outputs.sarif }}"
       - name: "Build, unit tests and integration tests"
         run: |
           chmod +x gradlew

--- a/.github/workflows/commit-stage.yaml
+++ b/.github/workflows/commit-stage.yaml
@@ -51,7 +51,7 @@ jobs:
       security-events: write
     steps:
       - name: "Checkout source code"
-        uses: /actions/checkout@v5
+        uses: actions/checkout@v5
       - name: "Set up JDK 25"
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/commit-stage.yaml
+++ b/.github/workflows/commit-stage.yaml
@@ -1,0 +1,85 @@
+name: "Commit Stage"
+on: "push"
+env:
+  REGISTRY: "ghcr.io"
+  IMAGE_NAME: "shayfoo/edge-service"
+  VERSION: "latest"
+jobs:
+  build:
+    name: "Build and Test"
+    runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v5
+      - name: "Set up JDK 25"
+        uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: "corretto"
+          cache: "gradle"
+      - name: "Code vulnerability scanning"
+        uses: "anchore/scan-action@v6"
+        id: scan
+        with:
+          path: "${{ github.workspace }}"
+          fail-build: "false"
+          severity-cutoff: high
+      - name: "Upload vulnerability report"
+        uses: "github/codeql-action/upload-sarif@v3"
+        with:
+          sarif_file: "${{ steps.scan.outputs.sarif}}"
+      - name: "Build, unit tests and integration tests"
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+      - name: Validate Kubernetes manifest
+        uses: "stackrox/kube-linter-action@v1.0.7"
+        with:
+          directory: k8s
+          fail-on-invalid-resource: true
+  package:
+    name: "Package and Publish"
+    if: "${{ github.ref == 'refs/heads/main'}}"
+    needs: [ "build" ]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    steps:
+      - name: "Checkout source code"
+        uses: /actions/checkout@v5
+      - name: "Set up JDK 25"
+        uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: "corretto"
+          cache: "gradle"
+      - name: "Build container image"
+        run: |
+          chmod +x gradlew
+          ./gradlew  bootBuildImage\
+            --imageName ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+      - name: "Image vulnerability scanning"
+        uses: "anchore/scan-action@v6"
+        id: scan
+        with:
+          image: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}"
+          fail-build: "true"
+          severity-cutoff: high
+      - name: "Upload vulnerability report"
+        uses: "github/codeql-action/upload-sarif@v3"
+        with:
+          sarif_file: "${{ steps.scan.outputs.sarif }}"
+      - name: "Log into container registry"
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish container image"
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/commit-stage.yaml
+++ b/.github/workflows/commit-stage.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: "Build container image"
         run: |
           chmod +x gradlew
-          ./gradlew  bootBuildImage\
+          ./gradlew bootBuildImage \
             --imageName ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
       - name: "Image vulnerability scanning"
         uses: "anchore/scan-action@v6"

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,18 @@
+# Build
+custom_build(
+    # Name of the container image
+    ref = 'edge-service',
+    # Command to build the image - using env parameter for cross-platform compatibility
+    command='gradlew bootBuildImage --imageName %EXPECTED_REF%',
+    # files to watch for changes
+    deps=['build.gradle.kts', 'src']
+)
+
+# Deploy
+k8s_yaml(['k8s/deployment.yaml', 'k8s/service.yaml'])
+
+# Manage
+k8s_resource(
+    'edge-service',
+    port_forwards=['9000']
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,19 +19,22 @@ repositories {
 }
 
 extra["springCloudVersion"] = "2025.0.0"
-
+extra["testcontainers.version"] = "1.21.3"
 dependencies {
 	implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j")
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+    implementation("org.springframework.session:spring-session-data-redis:3.5.2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("io.projectreactor:reactor-test")
+    testImplementation("org.testcontainers:junit-jupiter")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 dependencyManagement {
 	imports {
 		mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+        mavenBom("org.testcontainers:testcontainers-bom:${property("testcontainers.version")}")
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 	implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j")
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+    implementation("org.springframework.cloud:spring-cloud-starter-config")
     implementation("org.springframework.session:spring-session-data-redis:3.5.2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("io.projectreactor:reactor-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.kotlin.dsl.named
+import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
+
 plugins {
 	java
 	id("org.springframework.boot") version "3.5.6"
@@ -42,3 +45,22 @@ dependencyManagement {
 tasks.withType<Test> {
 	useJUnitPlatform()
 }
+
+tasks.named<BootBuildImage>("bootBuildImage") {
+    environment = mapOf(
+        "BP_JVM_VERSION" to "25",
+        "BP_JVM_TIMEZONE" to "Asia/Tokyo",
+        "LANG" to "ja_JP.UTF-8",
+        "LANGUAGE" to "ja_JP:ja",
+        "LC_ALL" to "ja_JP.UTF-8",
+    )
+    imageName = project.name + ":" + project.version
+    docker {
+        publishRegistry {
+            username = project.findProperty("registryUsername")?.toString()
+            password = project.findProperty("registryToken")?.toString()
+            url = project.findProject("registryUrl")?.toString()
+        }
+    }
+}
+

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-service
+  labels:
+    app: edge-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: edge-service
+  template:
+    metadata:
+      labels:
+        app: edge-service
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: edge-service
+          image: edge-service:0.0.1-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "sh", "-c", "sleep 5" ]
+          ports:
+            - containerPort: 9001
+          env:
+            - name: BPL_JVM_THREAD_COUNT
+              value: "50"
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:postgresql://polar-postgres/polardb_edge
+            - name: SPRING_PROFILES_ACTIVE
+              value: testdata
+            - name: SPRING_CLOUD_CONFIG_FAIL-FAST
+              value: "true"
+            - name: SPRING_CLOUD_CONFIG_RETRY_MAX-ATTEMPTS
+              value: "10"
+            - name: SPRING_CLOUD_CONFIG_URI
+              value: http://config-service
+            - name: CATALOG_SERVICE_URL
+              value: http://catalog-service
+            - name: ORDER_SERVICE_URL
+              value: http://order-service
+            - name: REDIS_HOST
+              value: redis
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "200m"
+            limits:
+              memory: "1024Mi"
+              cpu: "400m"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: { }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -25,7 +25,7 @@ spec:
               exec:
                 command: [ "sh", "-c", "sleep 5" ]
           ports:
-            - containerPort: 9001
+            - containerPort: 9000
           env:
             - name: BPL_JVM_THREAD_COUNT
               value: "50"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalog-service
+  labels:
+    app: catalog-service
+spec:
+  type: ClusterIP
+  selector:
+    app: catalog-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9001

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: catalog-service
+  name: edge-service
   labels:
-    app: catalog-service
+    app: edge-service
 spec:
   type: ClusterIP
   selector:
-    app: catalog-service
+    app: edge-service
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 9001
+      targetPort: 9000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,19 @@ spring:
     lifecycle:
       timeout-per-shutdown-phase: 15s
 # https://docs.spring.io/spring-cloud-gateway/reference/appendix.html
+    config:
+      import: "optional:configserver:"
     cloud:
+      config:
+          uri: http://localhost:8888
+          request-connect-timeout: 5000
+          request-read-timeout: 5000
+          fail-fast: false
+          retry:
+            max-attempts: 6
+            initial-interval: 1000
+            max-interval: 2000
+            multiplier: 1.1
       gateway:
         server:
           webflux:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,12 +60,17 @@ spring:
               redis-rate-limiter.replenishRate: 10
               redis-rate-limiter.burstCapacity: 20
               redis-rate-limiter.requestedTokens: 1
+          - SaveSession
     data:
       redis:
         connect-timeout: 2s
         host: ${REDIS_HOST:localhost}
         port: ${REDIS_PORT:6379}
         timeout: 1s
+    session:
+      timeout: 10m
+      redis:
+        namespace: polar:edge
 # https://docs.spring.io/spring-cloud-circuitbreaker/reference/spring-cloud-circuitbreaker-resilience4j/circuit-breaker-properties-configuration.html
 #https://resilience4j.readme.io/docs/getting-started-3#configuration
 resilience4j.circuitbreaker:

--- a/src/test/java/com/polarbookshop/edge_service/EdgeServiceApplicationTests.java
+++ b/src/test/java/com/polarbookshop/edge_service/EdgeServiceApplicationTests.java
@@ -2,12 +2,33 @@ package com.polarbookshop.edge_service;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
-@SpringBootTest
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@Testcontainers
 class EdgeServiceApplicationTests {
+    private static final int REDIS_PORT = 6379;
 
-	@Test
-	void contextLoads() {
-	}
+    @Container
+    static GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:8.2.1"))
+                    .withExposedPorts(REDIS_PORT);
+
+	@DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(REDIS_PORT));
+    }
+
+    @Test
+    void verifyContextLoads() {
+    }
 
 }


### PR DESCRIPTION
This pull request introduces automated CI/CD workflows, Kubernetes deployment manifests, and configuration improvements for the `edge-service`. The main changes include adding a GitHub Actions workflow for build and container publishing, Kubernetes manifests for deployment and service, a `Tiltfile` for local development and deployment, enhancements to Spring Cloud Config and Redis session management, and improved integration testing with Testcontainers.

**CI/CD and Containerization**
* Added `.github/workflows/commit-stage.yaml` to automate building, testing, vulnerability scanning, and publishing the container image for `edge-service` using GitHub Actions.
* Added a `Tiltfile` to enable local development workflows with custom container builds and Kubernetes resource management.

**Kubernetes Deployment**
* Added `k8s/deployment.yaml` for secure deployment of `edge-service` with resource limits, environment variables, and security context.
* Added `k8s/service.yaml` to expose the `edge-service` deployment via a Kubernetes ClusterIP service.

**Application Configuration**
* Updated `application.yml` to integrate Spring Cloud Config server with retry and timeout settings, and added Redis-backed session management for improved scalability and reliability. [[1]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR14-R26) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR75-R85)

**Testing Improvements**
* Enhanced `EdgeServiceApplicationTests.java` to use Testcontainers for Redis, enabling more robust and isolated integration tests.