### PR TITLE
add Ingress configuration for edge service

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: polar-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: edge-service
+                port: 
+                  number: 80


### PR DESCRIPTION
This pull request introduces a new Kubernetes ingress configuration to the repository. The main change is the addition of an `Ingress` resource to route external HTTP traffic to the `edge-service`.

Ingress configuration:

* Added a new `k8s/ingress.yaml` file defining an `Ingress` resource named `polar-ingress`, which uses the `nginx` ingress controller and forwards traffic on path `/` to the `edge-service` on port 80.