### PR TITLE
add Ingress configuration to Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -9,7 +9,7 @@ custom_build(
 )
 
 # Deploy
-k8s_yaml(['k8s/deployment.yaml', 'k8s/service.yaml'])
+k8s_yaml(['k8s/deployment.yaml', 'k8s/service.yaml', 'k8s/ingress.yaml'])
 
 # Manage
 k8s_resource(


### PR DESCRIPTION
This pull request makes a small change to the deployment configuration in the `Tiltfile`. The change adds `k8s/ingress.yaml` to the list of Kubernetes YAML files that are loaded for deployment.